### PR TITLE
Stretch Goal - Create Delete Feature

### DIFF
--- a/db.json
+++ b/db.json
@@ -1,123 +1,6 @@
 {
   "books": [
     {
-      "id": "1",
-      "author_name": [
-        "Stephen King"
-      ],
-      "cover_i": 9256116,
-      "first_publish_year": 1975,
-      "key": "/works/OL81632W",
-      "ratings_average": 4.0882354,
-      "subject": [
-        "Catholic Church",
-        "arson",
-        "Great Depression"
-      ],
-      "title": "Salem's Lot"
-    },
-    {
-      "id": "afd8",
-      "author_name": [
-        "Stephen King"
-      ],
-      "cover_i": 8569284,
-      "first_publish_year": 1986,
-      "key": "/works/OL81613W",
-      "title": "It",
-      "subject": [
-        "coming of age",
-        "thrillers",
-        "suspense",
-        "horror",
-        "Schwinn bicycles",
-        "catatonia",
-        "homosexuality",
-        "blood oaths",
-        "Omniscience",
-        "mummies",
-        "lepers",
-        "ghosts",
-        "we",
-        "clownrewolves",
-        "nonlinear narrative",
-        "third-person",
-        "Open Library Staff Picks",
-        "Fiction",
-        "Good and evil",
-        "horror stories",
-        "horror tales",
-        "Horror fiction",
-        "Reading Level-Grade 9",
-        "Reading Level-Grade 11",
-        "Reading Level-Grade 10",
-        "Reading Level-Grade 12",
-        "nyt:trade-fiction-paperback=2017-09-03",
-        "New York Times bestseller",
-        "New York Times reviewed",
-        "Fiction, horror",
-        "American literature"
-      ],
-      "ratings_average": 4.109005
-    },
-    {
-      "id": "5d5a",
-      "author_name": [
-        "Stephen King"
-      ],
-      "cover_i": 401165,
-      "first_publish_year": 1979,
-      "key": "/works/OL81630W",
-      "title": "The Dead Zone",
-      "subject": [
-        "brain tumors",
-        "rifles",
-        "human shields",
-        "assassination",
-        "procrastination",
-        "murder",
-        "Federal Bureau of Investigation",
-        "car bombs",
-        "United States House of Representatives",
-        "mayors",
-        "wheel of fortune",
-        "comas",
-        "high school teachers",
-        "precognition",
-        "brains",
-        "Clairvoyants",
-        "thrillers",
-        "Supernatural",
-        "Movie or Television Tie-In",
-        "suspense",
-        "horror fiction",
-        "science fiction",
-        "paranormal fiction",
-        "carnivals",
-        "good and evil",
-        "American Horror tales",
-        "Open Library Staff Picks",
-        "Fiction in English",
-        "Fiction",
-        "Translations into Russian",
-        "Psychics",
-        "Horror",
-        "Horror tales",
-        "Fiction, horror",
-        "New england, fiction",
-        "Smith, johnny (fictitious character), fiction",
-        "Large type books",
-        "American literature",
-        "Coma",
-        "Patients",
-        "Psychic ability",
-        "Media Tie-In",
-        "Médiums",
-        "Romans, nouvelles"
-      ],
-      "ratings_average": 4.1764708
-    },
-    {
       "id": "2b57",
       "author_name": [
         "Stephen King"
@@ -179,6 +62,21 @@
         "813/.54"
       ],
       "ratings_average": 4.125
+    },
+    {
+      "id": "d52b",
+      "author_name": [
+        "J. K. Rowling"
+      ],
+      "cover_i": 8457205,
+      "first_publish_year": 2014,
+      "key": "/works/OL18011053W",
+      "title": "Fantastic Beasts",
+      "subject": [
+        "Children's plays",
+        "Motion picture plays"
+      ],
+      "ratings_average": 3.3333333
     }
   ]
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 document.addEventListener("DOMContentLoaded", (e) => {
-
+  e.preventDefault()
   let form = document.getElementById("book-form")
   let coverImage = document.querySelector(".book-grid")
   let bookDetails = document.querySelector('.book-details-container')
@@ -79,6 +79,26 @@ document.addEventListener("DOMContentLoaded", (e) => {
       const libraryBook = document.createElement("img")
       libraryBook.src = `https://covers.openlibrary.org/b/id/${book.cover_i}-M.jpg`
       library.appendChild(libraryBook)
+
+      const deleteButton = document.createElement('button')
+      deleteButton.textContent = 'x'
+      library.appendChild(deleteButton)
+
+      deleteButton.addEventListener("click", (e) => {
+        fetch(`http://localhost:3000/books/${book.id}`, {
+          method: "DELETE",
+          headers: {
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+          },
+        })
+          .then(function (response) {
+            return response.json()
+          })
+          .then(data => {
+            deleteButton.parentNode.remove(data)
+          })
+      })
     })
   }
 

--- a/styles.css
+++ b/styles.css
@@ -32,7 +32,7 @@
 .library {
   width: 250px;
   background-color: #f0f0f0;
-  padding: 20px;
+  padding-bottom: 20%;
   position: fixed;
   top: 0;
   right: 0;


### PR DESCRIPTION
## Deliverables:

- [x] add 'deleteButton's to each book in the library
- [x] clicking the 'deleteButton' removes the book from the dom and db


Notes: I need to fix that all books disappear from the page on delete, but after refresh -- they all come back minus the one that was deleted from the DB.  Same thing for adding books to the library, but reversed. 

https://github.com/gabbymassaro/better-reads/assets/37029835/bb269313-be9e-48a1-86b0-6e6477ebab45